### PR TITLE
add scalers

### DIFF
--- a/tocount/params.py
+++ b/tocount/params.py
@@ -6,6 +6,12 @@ TOCOUNT_VERSION = "0.2"
 INVALID_TEXT_ESTIMATOR_MESSAGE = "Invalid value. `estimator` must be an instance of TextEstimator enum."
 INVALID_TEXT_MESSAGE = "Invalid value. `text` must be a string."
 
+# --- Model Parameters ---
+# The model coefficients ('a', 'b') are pre-scaled to operate directly on the
+# raw character count. They represent the simplified result of a full
+# StandardScaler pipeline, whose original parameters ('input_scaler',
+# 'output_scaler') are retained below for reproducibility.
+
 TIKTOKEN_R50K_LINEAR_MODELS = {
     "english": {
         "model": {"a": 0.22027472695240083, "b": 1.3098454987590542},

--- a/tocount/params.py
+++ b/tocount/params.py
@@ -7,11 +7,27 @@ INVALID_TEXT_ESTIMATOR_MESSAGE = "Invalid value. `estimator` must be an instance
 INVALID_TEXT_MESSAGE = "Invalid value. `text` must be a string."
 
 TIKTOKEN_R50K_LINEAR_MODELS = {
-    "english": {"a": 0.22027472695240083, "b": 1.3098454987590542},
-    "all":     {"a": 0.24897308965467127, "b": 4.5430826510558830}
+    "english": {
+        "model": {"a": 0.22027472695240083, "b": 1.3098454987590542},
+        "input_scaler": {"mean": 847.1859533518088, "scale": 4824.545962963612},
+        "output_scaler": {"mean": 191.91873679585714, "scale": 1122.038549166423}
+    },
+    "all": {
+        "model": {"a": 0.24897308965467127, "b": 4.543082651055883},
+        "input_scaler": {"mean": 863.9105273550211, "scale": 4579.146073191748},
+        "output_scaler": {"mean": 250.55580827419274, "scale": 1317.8399144012787}
+    }
 }
 
 TIKTOKEN_CL100K_LINEAR_MODELS = {
-    "english": {"a": 0.20632774595922751, "b": 1.31582377652722826},
-    "all":     {"a": 0.22359382657517404, "b": 4.81058433875418601}
+    "english": {
+        "model": {"a": 0.2063277459592275, "b": 1.3158237765272283},
+        "input_scaler": {"mean": 928.0135145581235, "scale": 4839.455147131051},
+        "output_scaler": {"mean": 198.34363306972855, "scale": 1087.618915250561}
+    },
+    "all": {
+        "model": {"a": 0.22359382657517404, "b": 4.810584338754186},
+        "input_scaler": {"mean": 874.1646054463054, "scale": 4486.7423868301485},
+        "output_scaler": {"mean": 213.8142892920311, "scale": 1078.2629716972262}
+    }
 }

--- a/tocount/params.py
+++ b/tocount/params.py
@@ -14,12 +14,12 @@ INVALID_TEXT_MESSAGE = "Invalid value. `text` must be a string."
 
 TIKTOKEN_R50K_LINEAR_MODELS = {
     "english": {
-        "model": {"a": 0.22027472695240083, "b": 1.3098454987590542},
+        "coefficient": {"a": 0.22027472695240083, "b": 1.3098454987590542},
         "input_scaler": {"mean": 847.1859533518088, "scale": 4824.545962963612},
         "output_scaler": {"mean": 191.91873679585714, "scale": 1122.038549166423}
     },
     "all": {
-        "model": {"a": 0.24897308965467127, "b": 4.543082651055883},
+        "coefficient": {"a": 0.24897308965467127, "b": 4.543082651055883},
         "input_scaler": {"mean": 863.9105273550211, "scale": 4579.146073191748},
         "output_scaler": {"mean": 250.55580827419274, "scale": 1317.8399144012787}
     }
@@ -27,12 +27,12 @@ TIKTOKEN_R50K_LINEAR_MODELS = {
 
 TIKTOKEN_CL100K_LINEAR_MODELS = {
     "english": {
-        "model": {"a": 0.2063277459592275, "b": 1.3158237765272283},
+        "coefficient": {"a": 0.2063277459592275, "b": 1.3158237765272283},
         "input_scaler": {"mean": 928.0135145581235, "scale": 4839.455147131051},
         "output_scaler": {"mean": 198.34363306972855, "scale": 1087.618915250561}
     },
     "all": {
-        "model": {"a": 0.22359382657517404, "b": 4.810584338754186},
+        "coefficient": {"a": 0.22359382657517404, "b": 4.810584338754186},
         "input_scaler": {"mean": 874.1646054463054, "scale": 4486.7423868301485},
         "output_scaler": {"mean": 213.8142892920311, "scale": 1078.2629716972262}
     }

--- a/tocount/tiktoken_cl100k/functions.py
+++ b/tocount/tiktoken_cl100k/functions.py
@@ -11,11 +11,25 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param model: model name
     """
     params = TIKTOKEN_CL100K_LINEAR_MODELS[model]
-    a = params["a"]
-    b = params["b"]
+
+    model_params = params["model"]
+    input_scaler_params = params["input_scaler"]
+    output_scaler_params = params["output_scaler"]
+
+    a = model_params["a"]
+    b = model_params["b"]
+
+    x_mean = input_scaler_params["mean"]
+    x_scale = input_scaler_params["scale"]
+
+    y_mean = output_scaler_params["mean"]
+    y_scale = output_scaler_params["scale"]
+
     char_count = len(text)
-    estimate = a * char_count + b
-    return int(round(estimate))
+    scaled_char_count = (char_count - x_mean) / x_scale
+    scaled_estimate = a * scaled_char_count + b
+    estimate = (scaled_estimate * y_scale) + y_mean
+    return int(round(max(0, estimate)))
 
 
 def linear_tokens_estimator_english(text: str) -> int:

--- a/tocount/tiktoken_cl100k/functions.py
+++ b/tocount/tiktoken_cl100k/functions.py
@@ -10,7 +10,7 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param text: input text
     :param model: model name
     """
-    params = params = TIKTOKEN_CL100K_LINEAR_MODELS[model]["model"]
+    params = TIKTOKEN_CL100K_LINEAR_MODELS[model]["model"]
     a = params["a"]
     b = params["b"]
     char_count = len(text)

--- a/tocount/tiktoken_cl100k/functions.py
+++ b/tocount/tiktoken_cl100k/functions.py
@@ -10,7 +10,7 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param text: input text
     :param model: model name
     """
-    params = TIKTOKEN_CL100K_LINEAR_MODELS[model]["model"]
+    params = TIKTOKEN_CL100K_LINEAR_MODELS[model]["coefficient"]
     a = params["a"]
     b = params["b"]
     char_count = len(text)

--- a/tocount/tiktoken_cl100k/functions.py
+++ b/tocount/tiktoken_cl100k/functions.py
@@ -10,30 +10,12 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param text: input text
     :param model: model name
     """
-    params = TIKTOKEN_CL100K_LINEAR_MODELS[model]
-
-    model_params = params["model"]
-    input_scaler_params = params["input_scaler"]
-    output_scaler_params = params["output_scaler"]
-
-    a = model_params["a"]
-    b = model_params["b"]
-
-    x_mean = input_scaler_params["mean"]
-    x_scale = input_scaler_params["scale"]
-
-    y_mean = output_scaler_params["mean"]
-    y_scale = output_scaler_params["scale"]
-
-    a_scaled = a * (x_scale / y_scale)
-    b_scaled = ((b - y_mean) + (a * x_mean)) / y_scale
-
+    params = params = TIKTOKEN_CL100K_LINEAR_MODELS[model]["model"]
+    a = params["a"]
+    b = params["b"]
     char_count = len(text)
-    scaled_char_count = (char_count - x_mean) / x_scale
-    scaled_estimate = a_scaled * scaled_char_count + b_scaled
-    estimate = (scaled_estimate * y_scale) + y_mean
-
-    return int(round(max(0, estimate)))
+    estimate = a * char_count + b
+    return int(round(estimate))
 
 
 def linear_tokens_estimator_english(text: str) -> int:

--- a/tocount/tiktoken_cl100k/functions.py
+++ b/tocount/tiktoken_cl100k/functions.py
@@ -25,10 +25,14 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     y_mean = output_scaler_params["mean"]
     y_scale = output_scaler_params["scale"]
 
+    a_scaled = a * (x_scale / y_scale)
+    b_scaled = ((b - y_mean) + (a * x_mean)) / y_scale
+
     char_count = len(text)
     scaled_char_count = (char_count - x_mean) / x_scale
-    scaled_estimate = a * scaled_char_count + b
+    scaled_estimate = a_scaled * scaled_char_count + b_scaled
     estimate = (scaled_estimate * y_scale) + y_mean
+
     return int(round(max(0, estimate)))
 
 

--- a/tocount/tiktoken_r50k/functions.py
+++ b/tocount/tiktoken_r50k/functions.py
@@ -10,30 +10,12 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param text: input text
     :param model: model name
     """
-    params = TIKTOKEN_R50K_LINEAR_MODELS[model]
-
-    model_params = params["model"]
-    input_scaler_params = params["input_scaler"]
-    output_scaler_params = params["output_scaler"]
-
-    a = model_params["a"]
-    b = model_params["b"]
-
-    x_mean = input_scaler_params["mean"]
-    x_scale = input_scaler_params["scale"]
-
-    y_mean = output_scaler_params["mean"]
-    y_scale = output_scaler_params["scale"]
-
-    a_scaled = a * (x_scale / y_scale)
-    b_scaled = ((b - y_mean) + (a * x_mean)) / y_scale
-
+    params = TIKTOKEN_R50K_LINEAR_MODELS[model]["model"]
+    a = params["a"]
+    b = params["b"]
     char_count = len(text)
-    scaled_char_count = (char_count - x_mean) / x_scale
-    scaled_estimate = a_scaled * scaled_char_count + b_scaled
-    estimate = (scaled_estimate * y_scale) + y_mean
-
-    return int(round(max(0, estimate)))
+    estimate = a * char_count + b
+    return int(round(estimate))
 
 
 def linear_tokens_estimator_english(text: str) -> int:

--- a/tocount/tiktoken_r50k/functions.py
+++ b/tocount/tiktoken_r50k/functions.py
@@ -11,11 +11,25 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param model: model name
     """
     params = TIKTOKEN_R50K_LINEAR_MODELS[model]
-    a = params["a"]
-    b = params["b"]
+
+    model_params = params["model"]
+    input_scaler_params = params["input_scaler"]
+    output_scaler_params = params["output_scaler"]
+
+    a = model_params["a"]
+    b = model_params["b"]
+
+    x_mean = input_scaler_params["mean"]
+    x_scale = input_scaler_params["scale"]
+
+    y_mean = output_scaler_params["mean"]
+    y_scale = output_scaler_params["scale"]
+
     char_count = len(text)
-    estimate = a * char_count + b
-    return int(round(estimate))
+    scaled_char_count = (char_count - x_mean) / x_scale
+    scaled_estimate = a * scaled_char_count + b
+    estimate = (scaled_estimate * y_scale) + y_mean
+    return int(round(max(0, estimate)))
 
 
 def linear_tokens_estimator_english(text: str) -> int:

--- a/tocount/tiktoken_r50k/functions.py
+++ b/tocount/tiktoken_r50k/functions.py
@@ -10,7 +10,7 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     :param text: input text
     :param model: model name
     """
-    params = TIKTOKEN_R50K_LINEAR_MODELS[model]["model"]
+    params = TIKTOKEN_R50K_LINEAR_MODELS[model]["coefficient"]
     a = params["a"]
     b = params["b"]
     char_count = len(text)

--- a/tocount/tiktoken_r50k/functions.py
+++ b/tocount/tiktoken_r50k/functions.py
@@ -25,10 +25,14 @@ def _linear_estimator(text: str, model: str = "english") -> int:
     y_mean = output_scaler_params["mean"]
     y_scale = output_scaler_params["scale"]
 
+    a_scaled = a * (x_scale / y_scale)
+    b_scaled = ((b - y_mean) + (a * x_mean)) / y_scale
+
     char_count = len(text)
     scaled_char_count = (char_count - x_mean) / x_scale
-    scaled_estimate = a * scaled_char_count + b
+    scaled_estimate = a_scaled * scaled_char_count + b_scaled
     estimate = (scaled_estimate * y_scale) + y_mean
+
     return int(round(max(0, estimate)))
 
 


### PR DESCRIPTION
This PR integrates `StandardScaler` parameters into the linear estimators. The prediction logic now correctly scales the input and inverse-transforms the output.
